### PR TITLE
Regex blocking mime type extensions with dot.

### DIFF
--- a/src/FileUpload/FileUpload.php
+++ b/src/FileUpload/FileUpload.php
@@ -348,7 +348,7 @@ class FileUpload
     public function setAllowMimeType($mime)
     {
         if (!empty($mime) AND is_string($mime)) {
-            if (preg_match("#^[-\w\+]+/[-\w\+]+$#", $mime)) {
+            if (preg_match("#^[-\w\+]+/[-\w\+\.]+$#", $mime)) {
                 $this->log("IMPORTANT! Mime %s enabled", $mime);
                 $this->allowed_mime_types[] = strtolower($mime);
                 $this->file["allowed_mime_types"][] = strtolower($mime);

--- a/src/FileUpload/FileUpload.php
+++ b/src/FileUpload/FileUpload.php
@@ -369,7 +369,7 @@ class FileUpload
     */
     public function setMimeHelping($name)
     {
-        if (!empty($mime) and is_string($name)) {
+        if (!empty($name) and is_string($name)) {
             if (array_key_exists($name, $this->mime_helping)) {
                 return $this->setAllowedMimeTypes($this->mime_helping[ $name ]);
             }


### PR DESCRIPTION
Hello,

You can simulate this issue using this method bellow:

`$file->setMimeHelping('document');`

It should return an array of document key from $mime_helping as defined:
```
'document'  =>    array(
            'application/msword',
            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
            'application/vnd.openxmlformats-officedocument.presentationml.presentation',
            'application/vnd.ms-powerpoint',
            'application/vnd.ms-excel',
            'application/vnd.oasis.opendocument.spreadsheet',
            'application/vnd.oasis.opendocument.presentation',
        )
```
But, because of the preg_match inside setAllowMimeType method, it only returns and define inside  allowed_mime_types attribute the first item of array, because this is the only valid expression for preg_match expression,
```
[allowed_mime_types] => Array
        (
            [0] => application/msword
        )

```
**TL;DR**
All mime types extensions using "dot" will not be setted, for example:
```
application/vnd.openxmlformats-officedocument.wordprocessingml.document
application/vnd.openxmlformats-officedocument.presentationml.presentation
application/vnd.ms-powerpoint
application/vnd.ms-excel
application/vnd.oasis.opendocument.spreadsheet
application/vnd.oasis.opendocument.presentation

```